### PR TITLE
print only missing changes in the check command

### DIFF
--- a/pkg/action/check.go
+++ b/pkg/action/check.go
@@ -40,7 +40,7 @@ func Check(plugins plugin.List, base string, ui ui.UI) {
 			text, _ := t.(string)
 			// right aligned Id
 			id := fmt.Sprintf(idFmt, id)
-			ui.Print(id, text)
+			ui.PrintShort(id, text)
 		}
 	}
 }

--- a/pkg/ui/oneline.go
+++ b/pkg/ui/oneline.go
@@ -14,10 +14,11 @@ type OneLine struct {
 	duration time.Duration
 }
 
-func (ol *OneLine) Start()               { ol.pt.start(ol.prefix, ol.duration) }
-func (ol *OneLine) Stop()                { ol.pt.stop() }
-func (ol *OneLine) AddJob(string)        { ol.WaitGroup.Add(1); ol.pt.max++ }
-func (ol *OneLine) JobDone(string)       { ol.pt.counter++; ol.WaitGroup.Done() }
-func (ol *OneLine) Wait()                { ol.WaitGroup.Wait(); ol.pt.maxOut(); ol.Refresh() }
-func (ol *OneLine) Refresh()             { ol.pt.print(ol.prefix) }
-func (ol *OneLine) Print(string, string) {}
+func (ol *OneLine) Start()                    { ol.pt.start(ol.prefix, ol.duration) }
+func (ol *OneLine) Stop()                     { ol.pt.stop() }
+func (ol *OneLine) AddJob(string)             { ol.WaitGroup.Add(1); ol.pt.max++ }
+func (ol *OneLine) JobDone(string)            { ol.pt.counter++; ol.WaitGroup.Done() }
+func (ol *OneLine) Wait()                     { ol.WaitGroup.Wait(); ol.pt.maxOut(); ol.Refresh() }
+func (ol *OneLine) Refresh()                  { ol.pt.print(ol.prefix) }
+func (ol *OneLine) Print(string, string)      {}
+func (ol *OneLine) PrintShort(string, string) {}

--- a/pkg/ui/quiet.go
+++ b/pkg/ui/quiet.go
@@ -12,10 +12,11 @@ type Quiet struct {
 	vopher.Runtime
 }
 
-func (quiet *Quiet) Start()               { quiet.Runtime.Start() }
-func (quiet *Quiet) Stop()                { quiet.Runtime.Stop() }
-func (quiet *Quiet) AddJob(id string)     { quiet.WaitGroup.Add(1) }
-func (quiet *Quiet) JobDone(id string)    { quiet.WaitGroup.Done() }
-func (quiet *Quiet) Print(id, msg string) {}
-func (quiet *Quiet) Wait()                { quiet.WaitGroup.Wait() }
-func (quiet *Quiet) Refresh()             {}
+func (quiet *Quiet) Start()                    { quiet.Runtime.Start() }
+func (quiet *Quiet) Stop()                     { quiet.Runtime.Stop() }
+func (quiet *Quiet) AddJob(id string)          { quiet.WaitGroup.Add(1) }
+func (quiet *Quiet) JobDone(id string)         { quiet.WaitGroup.Done() }
+func (quiet *Quiet) Print(id, msg string)      {}
+func (quiet *Quiet) PrintShort(id, msg string) {}
+func (quiet *Quiet) Wait()                     { quiet.WaitGroup.Wait() }
+func (quiet *Quiet) Refresh()                  {}

--- a/pkg/ui/simple.go
+++ b/pkg/ui/simple.go
@@ -73,5 +73,19 @@ func (simple *Simple) Print(id, msg string) {
 	simple.Unlock()
 }
 
+func (simple *Simple) PrintShort(id, msg string) {
+	scanner := bufio.NewScanner(strings.NewReader(msg))
+	scanner.Split(bufio.ScanLines)
+	simple.Lock()
+	for scanner.Scan() {
+		text := scanner.Text()
+		fmt.Println(id, text)
+		if strings.HasPrefix(strings.TrimSpace(text), "*") {
+			break
+		}
+	}
+	simple.Unlock()
+}
+
 func (simple *Simple) Wait()    { simple.WaitGroup.Wait() }
 func (simple *Simple) Refresh() {}

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -36,6 +36,7 @@ type UI interface {
 
 	AddJob(id string)
 	Print(id, msg string)
+	PrintShort(id, msg string)
 	JobDone(id string)
 	Wait() // wait for all jobs to be .Done()
 }


### PR DESCRIPTION
We printed last few commits which were made before the version we are using. From my point of view it's not needed, and makes it harder to see if I need to update something or not.

If no new changes has been committed to a repo, print only the last commit instead.